### PR TITLE
Add license tag

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@ setuptools.setup(
     name="uptime_kuma_monitor",
     version="1.0.0",
     description="Python wrapper around Uptime Kuma /metrics endpoint",
+    license="MIT",
     long_description=long_description,
     long_description_content_type="text/markdown",
     install_requires=["requests", "prometheus-client"],


### PR DESCRIPTION
Allow third-party tools (e. g., PyPI or `pyp2rpm`) to get the license details in a simple way.